### PR TITLE
Remove unnecessary patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 *.opt
 .idea/
 !composer.lock
+.phpcs.cache

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -19,7 +19,8 @@
 	<arg value="sp"/><!-- Show sniff and progress -->
 	<arg name="basepath" value="./"/><!-- Strip the file paths down to the relevant bit -->
 	<arg name="extensions" value="php"/>
-	<arg name="parallel" value="12"/><!-- Enables parallel processing when available for faster results. -->
+	<arg name="parallel" value="100"/><!-- Enables parallel processing when available for faster results. -->
+	<arg name="cache" value=".phpcs.cache"/>
 
 	<config name="installed_paths" value="vendor/phpcompatibility/php-compatibility,vendor/phpcompatibility/phpcompatibility-paragonie,vendor/phpcompatibility/phpcompatibility-wp,vendor/wp-coding-standards/wpcs"/>
 	<config name="testVersion" value="5.6-"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,12 +14,6 @@
 	<exclude-pattern>*/src/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*\.js</exclude-pattern>
-	<exclude-pattern>*\.mo</exclude-pattern>
-	<exclude-pattern>*\.po</exclude-pattern>
-	<exclude-pattern>*\.twig</exclude-pattern>
-	<exclude-pattern>*\.css</exclude-pattern>
-	<exclude-pattern>*\.scss</exclude-pattern>
 
 	<!-- How to scan -->
 	<arg value="sp"/><!-- Show sniff and progress -->


### PR DESCRIPTION
These patterns unnecessary because you are use the `<arg name="extensions" value="php"/>` and check only the PHP files.